### PR TITLE
キャッシュコントロールの見直し

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -6,6 +6,17 @@
       "**/.*",
       "**/node_modules/**"
     ],
+    "headers": [
+      {
+        "source" : "**/*.@(js|json)",
+        "headers" : [
+          {
+            "key" : "Cache-Control",
+            "value" : "no-cache"
+          }
+        ]
+      }
+    ],
     "redirects": [
       {
         "source" : "/api/v1/proposals",

--- a/web/assets/index.js
+++ b/web/assets/index.js
@@ -136,3 +136,5 @@ axios.get('/assets/proposals.json')
         proposalsMaster = proposals;
         proposalsInstance.proposals = proposals;
     })
+
+console.log("test");


### PR DESCRIPTION
.js と .json はキャッシュしないように。

* .js：再デプロイしたあとでも最新の内容が反映されるようにするため
* .json：採択結果などで更新が入った場合にすぐに反映されるようにするため